### PR TITLE
Move check for null to outside of met statemetns

### DIFF
--- a/scripts/1_get_raw_site.R
+++ b/scripts/1_get_raw_site.R
@@ -37,7 +37,10 @@
 #  -- Function will check to see if each type of data has been done yet before processing
 #  -- See get_point_raw.R for internal workflow & more details
 # -----------------------------------
-source("get_point_raw.R")
+wd.base = "~/Dropbox/PalEON_CR/met_ensemble/"
+setwd(wd.base)
+
+source("scripts/get_point_raw.R")
 
 
 # Downloading Harvard
@@ -47,14 +50,18 @@ source("get_point_raw.R")
 #         ldas.type="NLDAS", 
 #         GCM.list=c("MIROC-ESM", "MPI-ESM-P", "bcc-csm1-1", "IPSL-CM5A-LR", "CCSM4"))
 
+path.pecan="scripts/Pecan_modified"
+
 get.raw(wd.base="~/Dropbox/PalEON_CR/met_ensemble/",
         site.name="VCM",
         lat=35.89, lon=-106.53,
-        ldas.type="NLDAS",
-        GCM.list=c("MIROC-ESM", "MPI-ESM-P", "bcc-csm1-1", "IPSL-CM5A-LR", "CCSM4"))
+        Ameriflux=NULL,
+        ldas.type=NULL,
+        CRUNCEP=TRUE,
+        GCM.list=NULL,
+        path.pecan=path.pecan)
 
 
-path.pecan="scripts/Pecan_modified"
 # wd.base="/projectnb/dietzelab/paleon/met_ensemble/"
 # site.name="HARVARD" 
 # lat=42.54; lon=-72.18 

--- a/scripts/get_point_raw.R
+++ b/scripts/get_point_raw.R
@@ -133,7 +133,8 @@ if(!is.null(Ameriflux)){
 # ------------
 setwd(wd.base)
 # Figure out if we already have the LDAS we need
-if(!ldas.type %in% substr(met.done, 1, 5) & !is.null(ldas.type)) {
+if(!is.null(ldas.type)){
+if(!ldas.type %in% substr(met.done, 1, 5) ) {
   
   if(!ldas.type %in% c("NLDAS", "GLDAS")) stop("Invalid ldas.type!  Must be either 'NLDAS' or 'GLDAS'")
   if(ldas.type %in% c("GLDAS")) stop("LDAS changed permissions and GLDAS now non-functional. \n Please use another data set")
@@ -217,6 +218,7 @@ if(!ldas.type %in% substr(met.done, 1, 5) & !is.null(ldas.type)) {
   
   write.csv(ldas.df, file.path(path.out, paste0(ldas.type, "_", min(as.numeric(paste(ldas.df$year))), "-", max(as.numeric(paste(ldas.df$year))), ".csv")), row.names = F)
 }
+  }
 # -----------------------------------
 
 # -----------------------------------
@@ -225,7 +227,8 @@ if(!ldas.type %in% substr(met.done, 1, 5) & !is.null(ldas.type)) {
 setwd(wd.base)
 
 # Figure out if we've already processed the necessary CRUNCEP data
-if(!is.null(CRUNCEP) & !"CRUNCEP" %in% substr(met.done, 1, 7)) {
+if(!is.null(CRUNCEP)){
+if(!"CRUNCEP" %in% substr(met.done, 1, 7)) {
   # Get CRUNCEP data for each site if we don't already have it downloaded.  
   #  -- Uses Pecan scrip download.CRUNCEP_Global.R
   path.cruncep <- "data/paleon_sites/CRUNCEP" 
@@ -300,7 +303,7 @@ if(!is.null(CRUNCEP) & !"CRUNCEP" %in% substr(met.done, 1, 7)) {
   summary(cruncep.df)
   
   write.csv(cruncep.df, file.path(path.out, paste0("CRUNCEP_", min(as.numeric(paste(cruncep.df$year))), "-", max(as.numeric(paste(cruncep.df$year))), ".csv")), row.names = F)
-}
+}}
 # -----------------------------------
 
 


### PR DESCRIPTION
If the met type = NULL (case for it should not be downloaded), the rest
of the if() statement can’t be evaluated, so these need to be separate
with the NULL case taking priority